### PR TITLE
feature: Enable gradle build cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = 'paradisium'
+
+boolean isCiServer = System.getenv().containsKey("CI")
+
+buildCache {
+	local {
+		enabled = !isCiServer
+	}
+}


### PR DESCRIPTION
Let's be smarter and use some caching features to speed up test /
disable rerun of compilation steps.
